### PR TITLE
libsdl2: update to 2.0.5 on 10.5

### DIFF
--- a/devel/libsdl2/Portfile
+++ b/devel/libsdl2/Portfile
@@ -4,7 +4,17 @@ PortSystem      1.0
 
 name            libsdl2
 set my_name     SDL2
-version         2.0.3
+
+version         2.0.5
+checksums           rmd160  91283ce74bd451e83651910259cf226cae70e4bb \
+                    sha256  442038cf55965969f2ff06d976031813de643af9c9edc9e331bd761c242e8785
+
+
+# version       2.0.3
+#checksums       rmd160  e6f3718c7366c5da793c1454cf0ec0972e8bd347 \
+#                sha256  a5a69a6abf80bcce713fa873607735fe712f44276a7f048d60a61bb2f6b3c90c
+
+
 categories      devel multimedia
 platforms       macosx freebsd
 license         zlib
@@ -19,9 +29,6 @@ long_description \
 homepage        http://www.libsdl.org/
 master_sites    ${homepage}release/
 distname        ${my_name}-${version}
-
-checksums       rmd160  e6f3718c7366c5da793c1454cf0ec0972e8bd347 \
-                sha256  a5a69a6abf80bcce713fa873607735fe712f44276a7f048d60a61bb2f6b3c90c
 
 patch.pre_args            -p1
 configure.args-append     --without-x
@@ -58,7 +65,7 @@ platform darwin 8 {
 }
 
 platform darwin 9 {
-    patchfiles-append         patch-SDL2-2.0.3_OSX_105.diff
+    patchfiles-append         patch-SDL2-2.0.5_OSX_105.diff
 }
 
 post-destroot {

--- a/devel/libsdl2/files/patch-SDL2-2.0.5_OSX_105.diff
+++ b/devel/libsdl2/files/patch-SDL2-2.0.5_OSX_105.diff
@@ -1,0 +1,2063 @@
+diff -ru SDL2-2.0.5-orig/include/SDL_platform.h SDL2-2.0.5/include/SDL_platform.h
+--- SDL2-2.0.5-orig/include/SDL_platform.h	2018-05-23 15:07:36.000000000 +0200
++++ SDL2-2.0.5/include/SDL_platform.h	2018-05-23 15:08:00.000000000 +0200
+@@ -84,7 +84,9 @@
+ #undef __MACOSX__
+ #define __MACOSX__  1
+ #if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++#if 0
+ # error SDL for Mac OS X only supports deploying on 10.6 and above.
++#endif
+ #endif /* MAC_OS_X_VERSION_MIN_REQUIRED < 1060 */
+ #endif /* TARGET_OS_IPHONE */
+ #endif /* defined(__APPLE__) */
+diff -ru SDL2-2.0.5-orig/include/SDL_syswm.h SDL2-2.0.5/include/SDL_syswm.h
+--- SDL2-2.0.5-orig/include/SDL_syswm.h	2016-10-20 05:56:27.000000000 +0200
++++ SDL2-2.0.5/include/SDL_syswm.h	2018-05-23 14:54:15.000000000 +0200
+@@ -227,21 +227,29 @@
+ #if defined(SDL_VIDEO_DRIVER_COCOA)
+         struct
+         {
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+ #if defined(__OBJC__) && defined(__has_feature) && __has_feature(objc_arc)
+             NSWindow __unsafe_unretained *window; /* The Cocoa window */
+ #else
+             NSWindow *window;                     /* The Cocoa window */
+ #endif
++#else
++            NSWindow *window;                     /* The Cocoa window */
++#endif
+         } cocoa;
+ #endif
+ #if defined(SDL_VIDEO_DRIVER_UIKIT)
+         struct
+         {
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+ #if defined(__OBJC__) && defined(__has_feature) && __has_feature(objc_arc)
+             UIWindow __unsafe_unretained *window; /* The UIKit window */
+ #else
+             UIWindow *window;                     /* The UIKit window */
+ #endif
++#else
++            UIWindow *window;                     /* The UIKit window */
++#endif
+             GLuint framebuffer; /* The GL view's Framebuffer Object. It must be bound when rendering to the screen using GL. */
+             GLuint colorbuffer; /* The GL view's color Renderbuffer Object. It must be bound when SDL_GL_SwapWindow is called. */
+             GLuint resolveFramebuffer; /* The Framebuffer Object which holds the resolve color Renderbuffer, when MSAA is used. */
+Only in SDL2-2.0.5: libtool
+Only in SDL2-2.0.5: sdl2-config
+Only in SDL2-2.0.5: sdl2-config.cmake
+Only in SDL2-2.0.5: sdl2.pc
+diff -ru SDL2-2.0.5-orig/src/atomic/SDL_spinlock.c SDL2-2.0.5/src/atomic/SDL_spinlock.c
+--- SDL2-2.0.5-orig/src/atomic/SDL_spinlock.c	2016-10-20 05:56:26.000000000 +0200
++++ SDL2-2.0.5/src/atomic/SDL_spinlock.c	2018-05-23 14:54:15.000000000 +0200
+@@ -28,6 +28,10 @@
+ #include "SDL_mutex.h"
+ #include "SDL_timer.h"
+ 
++#if defined(__MACOSX__) || defined(__IPHONEOS__)
++#include <libkern/OSAtomic.h>
++#endif
++
+ #if !defined(HAVE_GCC_ATOMICS) && defined(__SOLARIS__)
+ #include <atomic.h>
+ #endif
+diff -ru SDL2-2.0.5-orig/src/file/cocoa/SDL_rwopsbundlesupport.m SDL2-2.0.5/src/file/cocoa/SDL_rwopsbundlesupport.m
+--- SDL2-2.0.5-orig/src/file/cocoa/SDL_rwopsbundlesupport.m	2016-10-20 05:56:26.000000000 +0200
++++ SDL2-2.0.5/src/file/cocoa/SDL_rwopsbundlesupport.m	2018-05-23 14:54:15.000000000 +0200
+@@ -33,7 +33,9 @@
+  Also, note the bundle layouts are different for iPhone and Mac.
+ */
+ FILE* SDL_OpenFPFromBundleOrFallback(const char *file, const char *mode)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
++#endif
+ {
+     FILE* fp = NULL;
+ 
+@@ -42,6 +44,9 @@
+         return fopen(file, mode);
+     }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    NSAutoreleasePool* autorelease_pool = [[NSAutoreleasePool alloc] init];
++#endif
+     NSFileManager* file_manager = [NSFileManager defaultManager];
+     NSString* resource_path = [[NSBundle mainBundle] resourcePath];
+ 
+@@ -54,8 +59,15 @@
+         fp = fopen(file, mode);
+     }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    [autorelease_pool drain];
++#endif
+     return fp;
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++}
++#else
+ }}
++#endif
+ 
+ #endif /* __APPLE__ */
+ 
+diff -ru SDL2-2.0.5-orig/src/filesystem/cocoa/SDL_sysfilesystem.m SDL2-2.0.5/src/filesystem/cocoa/SDL_sysfilesystem.m
+--- SDL2-2.0.5-orig/src/filesystem/cocoa/SDL_sysfilesystem.m	2016-10-20 05:56:26.000000000 +0200
++++ SDL2-2.0.5/src/filesystem/cocoa/SDL_sysfilesystem.m	2018-05-23 14:54:15.000000000 +0200
+@@ -35,8 +35,13 @@
+ 
+ char *
+ SDL_GetBasePath(void)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     NSBundle *bundle = [NSBundle mainBundle];
+     const char* baseType = [[[bundle infoDictionary] objectForKey:@"SDL_FILESYSTEM_BASE_DIR_TYPE"] UTF8String];
+     const char *base = NULL;
+@@ -64,13 +69,24 @@
+         }
+     }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+     return retval;
+ }}
++#else
++    [pool release];
++    return retval;
++}
++#endif
+ 
+ char *
+ SDL_GetPrefPath(const char *org, const char *app)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     char *retval = NULL;
+ 
+     NSArray *array = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
+@@ -98,8 +114,14 @@
+         }
+     }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+     return retval;
+ }}
++#else
++    [pool release];
++    return retval;
++}
++#endif
+ 
+ #endif /* SDL_FILESYSTEM_COCOA */
+ 
+diff -ru SDL2-2.0.5-orig/src/joystick/darwin/SDL_sysjoystick.c SDL2-2.0.5/src/joystick/darwin/SDL_sysjoystick.c
+--- SDL2-2.0.5-orig/src/joystick/darwin/SDL_sysjoystick.c	2016-10-20 05:56:26.000000000 +0200
++++ SDL2-2.0.5/src/joystick/darwin/SDL_sysjoystick.c	2018-05-23 16:51:32.000000000 +0200
+@@ -436,7 +436,11 @@
+     device->instance_id = ++s_joystick_instance_id;
+ 
+     /* We have to do some storage of the io_service_t for SDL_HapticOpenFromJoystick */
++    #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+     ioservice = IOHIDDeviceGetService(ioHIDDeviceObject);
++    #else
++    ioservice = 0;
++    #endif
+ #if SDL_HAPTIC_IOKIT
+     if ((ioservice) && (FFIsForceFeedback(ioservice) == FF_OK)) {
+         device->ffservice = ioservice;
+diff -ru SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoaclipboard.m SDL2-2.0.5/src/video/cocoa/SDL_cocoaclipboard.m
+--- SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoaclipboard.m	2016-10-20 05:56:26.000000000 +0200
++++ SDL2-2.0.5/src/video/cocoa/SDL_cocoaclipboard.m	2018-05-23 15:51:40.000000000 +0200
+@@ -25,27 +25,64 @@
+ #include "SDL_cocoavideo.h"
+ #include "../../events/SDL_clipboardevents_c.h"
+ 
++static NSString *
++GetTextFormat(_THIS)
++{
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
++    if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_5) {
++        return NSPasteboardTypeString;
++    } else {
++#endif
++        return NSStringPboardType;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
++    }
++#endif
++}
++
+ int
+ Cocoa_SetClipboardText(_THIS, const char *text)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{   NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
++#endif
+     SDL_VideoData *data = (SDL_VideoData *) _this->driverdata;
+     NSPasteboard *pasteboard;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+     NSString *format = NSPasteboardTypeString;
++#else
++    NSString *format = GetTextFormat(_this);
++#endif
+ 
+     pasteboard = [NSPasteboard generalPasteboard];
+     data->clipboard_count = [pasteboard declareTypes:[NSArray arrayWithObject:format] owner:nil];
+     [pasteboard setString:[NSString stringWithUTF8String:text] forType:format];
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    [pool release];
++#endif
+     return 0;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++}
++#endif
+ 
+ char *
+ Cocoa_GetClipboardText(_THIS)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{   NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
++#endif
+     NSPasteboard *pasteboard;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+     NSString *format = NSPasteboardTypeString;
++#else
++    NSString *format = GetTextFormat(_this);
++#endif
+     NSString *available;
+     char *text;
+ 
+@@ -66,8 +103,15 @@
+         text = SDL_strdup("");
+     }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    [pool release];
++#endif
+     return text;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++}
++#endif
+ 
+ SDL_bool
+ Cocoa_HasClipboardText(_THIS)
+@@ -83,8 +127,12 @@
+ 
+ void
+ Cocoa_CheckClipboardUpdate(struct SDL_VideoData * data)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{   NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
++#endif
+     NSPasteboard *pasteboard;
+     NSInteger count;
+ 
+@@ -96,7 +144,12 @@
+         }
+         data->clipboard_count = count;
+     }
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
+ 
+ #endif /* SDL_VIDEO_DRIVER_COCOA */
+ 
+diff -ru SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoaevents.m SDL2-2.0.5/src/video/cocoa/SDL_cocoaevents.m
+--- SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoaevents.m	2016-10-20 05:56:26.000000000 +0200
++++ SDL2-2.0.5/src/video/cocoa/SDL_cocoaevents.m	2018-05-23 16:02:16.000000000 +0200
+@@ -97,7 +97,11 @@
+ - (void)setAppleMenu:(NSMenu *)menu;
+ @end
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+ @interface SDLAppDelegate : NSObject <NSApplicationDelegate> {
++#else
++@interface SDLAppDelegate : NSObject {
++#endif
+ @public
+     BOOL seenFirstActivate;
+ }
+@@ -157,8 +161,10 @@
+      */
+     for (NSWindow *window in [NSApp orderedWindows]) {
+         if (window != win && [window canBecomeKeyWindow]) {
+-            if (![window isOnActiveSpace]) {
+-                continue;
++            if ([window respondsToSelector:@selector(isOnActiveSpace)]) {
++                if (![window isOnActiveSpace]) {
++                    continue;
++                }
+             }
+             [window makeKeyAndOrderFront:self];
+             return;
+@@ -328,6 +334,7 @@
+     [windowMenu release];
+ 
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+     /* Add the fullscreen view toggle menu option, if supported */
+     if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6) {
+         /* Create the view menu */
+@@ -345,12 +352,18 @@
+ 
+         [viewMenu release];
+     }
++#endif
+ }
+ 
+ void
+ Cocoa_RegisterApp(void)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     /* This can get called more than once! Be careful what you initialize! */
+ 
+     if (NSApp == nil) {
+@@ -360,7 +373,11 @@
+         s_bShouldHandleEventsInSDLApplication = SDL_TRUE;
+ 
+         if (!SDL_GetHintBoolean(SDL_HINT_MAC_BACKGROUND_APP, SDL_FALSE)) {
++#if defined(MAC_OS_X_VERSION_10_6)
++#if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_6
+             [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
++#endif
++#endif
+             [NSApp activateIgnoringOtherApps:YES];
+ 		}
+ 		
+@@ -388,12 +405,22 @@
+             appDelegate->seenFirstActivate = YES;
+         }
+     }
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
+ 
+ void
+ Cocoa_PumpEvents(_THIS)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool;
++#endif
+     /* Update activity every 30 seconds to prevent screensaver */
+     SDL_VideoData *data = (SDL_VideoData *)_this->driverdata;
+     if (_this->suspend_screensaver && !data->screensaver_use_iopm) {
+@@ -405,6 +432,9 @@
+         }
+     }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    pool = [[NSAutoreleasePool alloc] init];
++#endif
+     for ( ; ; ) {
+         NSEvent *event = [NSApp nextEventMatchingMask:NSAnyEventMask untilDate:[NSDate distantPast] inMode:NSDefaultRunLoopMode dequeue:YES ];
+         if ( event == nil ) {
+@@ -418,10 +448,16 @@
+         // Pass events down to SDLApplication to be handled in sendEvent:
+         [NSApp sendEvent:event];
+     }
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
+ 
+ void
+ Cocoa_SuspendScreenSaver(_THIS)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
+     SDL_VideoData *data = (SDL_VideoData *)_this->driverdata;
+@@ -448,6 +484,10 @@
+                                            &data->screensaver_assertion);
+     }
+ }}
++#else
++{
++}
++#endif
+ 
+ #endif /* SDL_VIDEO_DRIVER_COCOA */
+ 
+diff -ru SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoakeyboard.m SDL2-2.0.5/src/video/cocoa/SDL_cocoakeyboard.m
+--- SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoakeyboard.m	2016-10-20 05:56:26.000000000 +0200
++++ SDL2-2.0.5/src/video/cocoa/SDL_cocoakeyboard.m	2018-05-23 16:07:08.000000000 +0200
+@@ -143,11 +143,15 @@
+             aRange.location, aRange.length, windowHeight,
+             NSStringFromRect(rect));
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+     if ([window respondsToSelector:@selector(convertRectToScreen:)]) {
+         rect = [window convertRectToScreen:rect];
+     } else {
++#endif
+         rect.origin = [window convertBaseToScreen:rect.origin];
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+     }
++#endif
+ 
+     return rect;
+ }
+@@ -588,8 +592,13 @@
+ 
+ void
+ Cocoa_StartTextInput(_THIS)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     SDL_VideoData *data = (SDL_VideoData *) _this->driverdata;
+     SDL_Window *window = SDL_GetKeyboardFocus();
+     NSWindow *nswindow = nil;
+@@ -615,20 +624,37 @@
+         [parentView addSubview: data->fieldEdit];
+         [nswindow makeFirstResponder: data->fieldEdit];
+     }
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
+ 
+ void
+ Cocoa_StopTextInput(_THIS)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
++#endif
+ {
+     SDL_VideoData *data = (SDL_VideoData *) _this->driverdata;
+ 
+     if (data && data->fieldEdit) {
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++        NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+         [data->fieldEdit removeFromSuperview];
+         [data->fieldEdit release];
+         data->fieldEdit = nil;
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++        [pool release];
++#endif
+     }
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++}
++#endif
+ 
+ void
+ Cocoa_SetTextInputRect(_THIS, SDL_Rect *rect)
+diff -ru SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoamessagebox.m SDL2-2.0.5/src/video/cocoa/SDL_cocoamessagebox.m
+--- SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoamessagebox.m	2016-10-20 05:56:26.000000000 +0200
++++ SDL2-2.0.5/src/video/cocoa/SDL_cocoamessagebox.m	2018-05-23 14:54:15.000000000 +0200
+@@ -79,10 +79,15 @@
+ /* Display a Cocoa message box */
+ int
+ Cocoa_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonid)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
++#endif
+ {
+     Cocoa_RegisterApp();
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     NSAlert* alert = [[[NSAlert alloc] init] autorelease];
+ 
+     if (messageboxdata->flags & SDL_MESSAGEBOX_ERROR) {
+@@ -124,8 +129,15 @@
+         returnValue = SDL_SetError("Did not get a valid `clicked button' id: %ld", (long)clicked);
+     }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    [pool release];
++#endif
+     return returnValue;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++}
++#endif
+ 
+ #endif /* SDL_VIDEO_DRIVER_COCOA */
+ 
+diff -ru SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoamodes.h SDL2-2.0.5/src/video/cocoa/SDL_cocoamodes.h
+--- SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoamodes.h	2016-10-20 05:56:26.000000000 +0200
++++ SDL2-2.0.5/src/video/cocoa/SDL_cocoamodes.h	2018-05-23 15:45:59.000000000 +0200
+@@ -30,7 +30,11 @@
+ 
+ typedef struct
+ {
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+     CGDisplayModeRef moderef;
++#else
++    const void *moderef;
++#endif
+ } SDL_DisplayModeData;
+ 
+ extern void Cocoa_InitModes(_THIS);
+diff -ru SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoamodes.m SDL2-2.0.5/src/video/cocoa/SDL_cocoamodes.m
+--- SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoamodes.m	2016-10-20 05:56:26.000000000 +0200
++++ SDL2-2.0.5/src/video/cocoa/SDL_cocoamodes.m	2018-05-23 16:29:51.000000000 +0200
+@@ -100,21 +100,37 @@
+ }
+ 
+ static SDL_bool
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+ GetDisplayMode(_THIS, CGDisplayModeRef vidmode, CVDisplayLinkRef link, SDL_DisplayMode *mode)
++#else
++GetDisplayMode(_THIS, const void *moderef, CVDisplayLinkRef link, SDL_DisplayMode *mode)
++#endif
+ {
+     SDL_DisplayModeData *data;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+     int width = 0;
+     int height = 0;
+     int bpp = 0;
+     int refreshRate = 0;
+     CFStringRef fmt;
++#else
++    long width = 0;
++    long height = 0;
++    long bpp = 0;
++    long refreshRate = 0;
++#endif
+ 
+     data = (SDL_DisplayModeData *) SDL_malloc(sizeof(*data));
+     if (!data) {
+         return SDL_FALSE;
+     }
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+     data->moderef = vidmode;
++#else
++    data->moderef = moderef;
++#endif
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+     fmt = CGDisplayModeCopyPixelEncoding(vidmode);
+     width = (int) CGDisplayModeGetWidth(vidmode);
+     height = (int) CGDisplayModeGetHeight(vidmode);
+@@ -134,6 +150,22 @@
+     }
+ 
+     CFRelease(fmt);
++#else
++    {
++        CFNumberRef number;
++        double refresh;
++        CFDictionaryRef vidmode = (CFDictionaryRef) moderef;
++        number = CFDictionaryGetValue(vidmode, kCGDisplayWidth);
++        CFNumberGetValue(number, kCFNumberLongType, &width);
++        number = CFDictionaryGetValue(vidmode, kCGDisplayHeight);
++        CFNumberGetValue(number, kCFNumberLongType, &height);
++        number = CFDictionaryGetValue(vidmode, kCGDisplayBitsPerPixel);
++        CFNumberGetValue(number, kCFNumberLongType, &bpp);
++        number = CFDictionaryGetValue(vidmode, kCGDisplayRefreshRate);
++        CFNumberGetValue(number, kCFNumberDoubleType, &refresh);
++        refreshRate = (long) (refresh + 0.5);
++    }
++#endif
+ 
+     /* CGDisplayModeGetRefreshRate returns 0 for many non-CRT displays. */
+     if (refreshRate == 0 && link != NULL) {
+@@ -182,8 +214,13 @@
+ 
+ void
+ Cocoa_InitModes(_THIS)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     CGDisplayErr result;
+     CGDirectDisplayID *displays;
+     CGDisplayCount numDisplays;
+@@ -192,6 +229,9 @@
+     result = CGGetOnlineDisplayList(0, NULL, &numDisplays);
+     if (result != kCGErrorSuccess) {
+         CG_SetError("CGGetOnlineDisplayList()", result);
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++        [pool release];
++#endif
+         return;
+     }
+     displays = SDL_stack_alloc(CGDirectDisplayID, numDisplays);
+@@ -199,6 +239,9 @@
+     if (result != kCGErrorSuccess) {
+         CG_SetError("CGGetOnlineDisplayList()", result);
+         SDL_stack_free(displays);
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++        [pool release];
++#endif
+         return;
+     }
+ 
+@@ -208,7 +251,11 @@
+             SDL_VideoDisplay display;
+             SDL_DisplayData *displaydata;
+             SDL_DisplayMode mode;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+             CGDisplayModeRef moderef = NULL;
++#else
++            const void *moderef = NULL;
++#endif
+             CVDisplayLinkRef link = NULL;
+ 
+             if (pass == 0) {
+@@ -225,7 +272,11 @@
+                 continue;
+             }
+ 
++            #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+             moderef = CGDisplayCopyDisplayMode(displays[i]);
++            #else
++            moderef = CGDisplayCurrentMode(displays[i]);
++            #endif
+ 
+             if (!moderef) {
+                 continue;
+@@ -233,7 +284,9 @@
+ 
+             displaydata = (SDL_DisplayData *) SDL_malloc(sizeof(*displaydata));
+             if (!displaydata) {
++            #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+                 CGDisplayModeRelease(moderef);
++            #endif
+                 continue;
+             }
+             displaydata->display = displays[i];
+@@ -245,7 +298,9 @@
+             display.name = (char *)Cocoa_GetDisplayName(displays[i]);
+             if (!GetDisplayMode(_this, moderef, link, &mode)) {
+                 CVDisplayLinkRelease(link);
++            #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+                 CGDisplayModeRelease(moderef);
++            #endif
+                 SDL_free(display.name);
+                 SDL_free(displaydata);
+                 continue;
+@@ -261,7 +316,12 @@
+         }
+     }
+     SDL_stack_free(displays);
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    [pool release];
++}
++#else
+ }}
++#endif
+ 
+ int
+ Cocoa_GetDisplayBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect)
+@@ -340,7 +400,11 @@
+ Cocoa_GetDisplayModes(_THIS, SDL_VideoDisplay * display)
+ {
+     SDL_DisplayData *data = (SDL_DisplayData *) display->driverdata;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+     CFArrayRef modes = CGDisplayCopyAllDisplayModes(data->display, NULL);
++#else
++    CFArrayRef modes = CGDisplayAvailableModes(data->display);
++#endif
+ 
+     if (modes) {
+         CVDisplayLinkRef link = NULL;
+@@ -350,10 +414,16 @@
+         CVDisplayLinkCreateWithCGDisplay(data->display, &link);
+ 
+         for (i = 0; i < count; i++) {
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+             CGDisplayModeRef moderef = (CGDisplayModeRef) CFArrayGetValueAtIndex(modes, i);
++#else
++            const void *moderef = CFArrayGetValueAtIndex(modes, i);
++#endif
+             SDL_DisplayMode mode;
+             if (GetDisplayMode(_this, moderef, link, &mode)) {
++                #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+                 CGDisplayModeRetain(moderef);
++                #endif
+                 SDL_AddDisplayMode(display, &mode);
+             }
+         }
+@@ -378,7 +448,11 @@
+ 
+     if (data == display->desktop_mode.driverdata) {
+         /* Restoring desktop mode */
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+         CGDisplaySetDisplayMode(displaydata->display, data->moderef, NULL);
++#else
++        CGDisplaySwitchToMode(displaydata->display, data->moderef);
++#endif
+ 
+         if (CGDisplayIsMain(displaydata->display)) {
+             CGReleaseAllDisplays();
+@@ -403,7 +477,11 @@
+         }
+ 
+         /* Do the physical switch */
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+         result = CGDisplaySetDisplayMode(displaydata->display, data->moderef, NULL);
++#else
++        result = CGDisplaySwitchToMode(displaydata->display, data->moderef);
++#endif
+         if (result != kCGErrorSuccess) {
+             CG_SetError("CGDisplaySwitchToMode()", result);
+             goto ERR_NO_SWITCH;
+@@ -448,11 +526,15 @@
+         }
+ 
+         mode = (SDL_DisplayModeData *) display->desktop_mode.driverdata;
++        #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+         CGDisplayModeRelease(mode->moderef);
++        #endif
+ 
+         for (j = 0; j < display->num_display_modes; j++) {
+             mode = (SDL_DisplayModeData*) display->display_modes[j].driverdata;
++        #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+             CGDisplayModeRelease(mode->moderef);
++        #endif
+         }
+ 
+     }
+diff -ru SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoamouse.m SDL2-2.0.5/src/video/cocoa/SDL_cocoamouse.m
+--- SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoamouse.m	2016-10-20 05:56:26.000000000 +0200
++++ SDL2-2.0.5/src/video/cocoa/SDL_cocoamouse.m	2018-05-23 14:54:15.000000000 +0200
+@@ -66,8 +66,13 @@
+ 
+ static SDL_Cursor *
+ Cocoa_CreateDefaultCursor()
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     NSCursor *nscursor;
+     SDL_Cursor *cursor = NULL;
+ 
+@@ -81,13 +86,25 @@
+         }
+     }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    [pool release];
++#endif
+     return cursor;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++}
++#endif
+ 
+ static SDL_Cursor *
+ Cocoa_CreateCursor(SDL_Surface * surface, int hot_x, int hot_y)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     NSImage *nsimage;
+     NSCursor *nscursor = NULL;
+     SDL_Cursor *cursor = NULL;
+@@ -106,13 +123,25 @@
+         }
+     }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    [pool release];
++#endif
+     return cursor;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++}
++#endif
+ 
+ static SDL_Cursor *
+ Cocoa_CreateSystemCursor(SDL_SystemCursor id)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     NSCursor *nscursor = NULL;
+     SDL_Cursor *cursor = NULL;
+ 
+@@ -165,23 +194,45 @@
+         }
+     }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    [pool release];
++#endif
+     return cursor;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++}
++#endif
+ 
+ static void
+ Cocoa_FreeCursor(SDL_Cursor * cursor)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     NSCursor *nscursor = (NSCursor *)cursor->driverdata;
+ 
+     [nscursor release];
+     SDL_free(cursor);
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
+ 
+ static int
+ Cocoa_ShowCursor(SDL_Cursor * cursor)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     SDL_VideoDevice *device = SDL_GetVideoDevice();
+     SDL_Window *window = (device ? device->windows : NULL);
+     for (; window != NULL; window = window->next) {
+@@ -192,8 +243,15 @@
+                                                 waitUntilDone:NO];
+         }
+     }
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    [pool release];
++#endif
+     return 0;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++}
++#endif
+ 
+ static SDL_Window *
+ SDL_FindWindowAtPoint(const int x, const int y)
+diff -ru SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoaopengl.m SDL2-2.0.5/src/video/cocoa/SDL_cocoaopengl.m
+--- SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoaopengl.m	2016-10-20 05:56:26.000000000 +0200
++++ SDL2-2.0.5/src/video/cocoa/SDL_cocoaopengl.m	2018-05-23 14:54:15.000000000 +0200
+@@ -150,11 +150,20 @@
+ 
+ SDL_GLContext
+ Cocoa_GL_CreateContext(_THIS, SDL_Window * window)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool;
++#endif
+     SDL_VideoDisplay *display = SDL_GetDisplayForWindow(window);
+     SDL_DisplayData *displaydata = (SDL_DisplayData *)display->driverdata;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1670
+     SDL_bool lion_or_later = floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6;
++#else
++    SDL_bool lion_or_later = SDL_FALSE;
++#endif
+     NSOpenGLPixelFormatAttribute attr[32];
+     NSOpenGLPixelFormat *fmt;
+     SDLOpenGLContext *context;
+@@ -175,7 +184,11 @@
+ 
+     attr[i++] = NSOpenGLPFAAllowOfflineRenderers;
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    pool = [[NSAutoreleasePool alloc] init];
++#endif
+     /* specify a profile if we're on Lion (10.7) or later. */
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+     if (lion_or_later) {
+         NSOpenGLPixelFormatAttribute profile = NSOpenGLProfileVersionLegacy;
+         if (_this->gl_config.profile_mask == SDL_GL_CONTEXT_PROFILE_CORE) {
+@@ -184,6 +197,7 @@
+         attr[i++] = NSOpenGLPFAOpenGLProfile;
+         attr[i++] = profile;
+     }
++#endif
+ 
+     attr[i++] = NSOpenGLPFAColorSize;
+     attr[i++] = SDL_BYTESPERPIXEL(display->current_mode.format)*8;
+@@ -239,6 +253,9 @@
+     fmt = [[NSOpenGLPixelFormat alloc] initWithAttributes:attr];
+     if (fmt == nil) {
+         SDL_SetError("Failed creating OpenGL pixel format");
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++        [pool release];
++#endif
+         return NULL;
+     }
+ 
+@@ -252,12 +269,18 @@
+ 
+     if (context == nil) {
+         SDL_SetError("Failed creating OpenGL context");
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++        [pool release];
++#endif
+         return NULL;
+     }
+ 
+     if ( Cocoa_GL_MakeCurrent(_this, window, context) < 0 ) {
+         Cocoa_GL_DeleteContext(_this, context);
+         SDL_SetError("Failed making OpenGL context current");
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++        [pool release];
++#endif
+         return NULL;
+     }
+ 
+@@ -272,6 +295,9 @@
+         if (!glGetStringFunc) {
+             Cocoa_GL_DeleteContext(_this, context);
+             SDL_SetError ("Failed getting OpenGL glGetString entry point");
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++            [pool release];
++#endif
+             return NULL;
+         }
+ 
+@@ -279,12 +305,18 @@
+         if (glversion == NULL) {
+             Cocoa_GL_DeleteContext(_this, context);
+             SDL_SetError ("Failed getting OpenGL context version");
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++            [pool release];
++#endif
+             return NULL;
+         }
+ 
+         if (SDL_sscanf(glversion, "%d.%d", &glversion_major, &glversion_minor) != 2) {
+             Cocoa_GL_DeleteContext(_this, context);
+             SDL_SetError ("Failed parsing OpenGL context version");
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++            [pool release];
++#endif
+             return NULL;
+         }
+ 
+@@ -292,6 +324,9 @@
+            ((glversion_major == _this->gl_config.major_version) && (glversion_minor < _this->gl_config.minor_version))) {
+             Cocoa_GL_DeleteContext(_this, context);
+             SDL_SetError ("Failed creating OpenGL context at version requested");
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++            [pool release];
++#endif
+             return NULL;
+         }
+ 
+@@ -301,13 +336,25 @@
+         /*_this->gl_config.major_version = glversion_major;*/
+         /*_this->gl_config.minor_version = glversion_minor;*/
+     }
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    [pool release];
++#endif
+     return context;
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++}
++#else
+ }}
++#endif
+ 
+ int
+ Cocoa_GL_MakeCurrent(_THIS, SDL_Window * window, SDL_GLContext context)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     if (context) {
+         SDLOpenGLContext *nscontext = (SDLOpenGLContext *)context;
+         [nscontext setWindow:window];
+@@ -317,8 +364,15 @@
+         [NSOpenGLContext clearCurrentContext];
+     }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    [pool release];
++#endif
+     return 0;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++}
++#endif
+ 
+ void
+ Cocoa_GL_GetDrawableSize(_THIS, SDL_Window * window, int * w, int * h)
+@@ -329,9 +383,11 @@
+ 
+     /* This gives us the correct viewport for a Retina-enabled view, only
+      * supported on 10.7+. */
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+     if ([contentView respondsToSelector:@selector(convertRectToBacking:)]) {
+         viewport = [contentView convertRectToBacking:viewport];
+     }
++#endif
+ 
+     if (w) {
+         *w = viewport.size.width;
+@@ -344,7 +400,9 @@
+ 
+ int
+ Cocoa_GL_SetSwapInterval(_THIS, int interval)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
++#endif
+ {
+     NSOpenGLContext *nscontext;
+     GLint value;
+@@ -353,6 +411,9 @@
+     if (interval < 0) {  /* no extension for this on Mac OS X at the moment. */
+         return SDL_SetError("Late swap tearing currently unsupported");
+     }
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+ 
+     nscontext = (NSOpenGLContext*)SDL_GL_GetCurrentContext();
+     if (nscontext != nil) {
+@@ -363,13 +424,25 @@
+         status = SDL_SetError("No current OpenGL context");
+     }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    [pool release];
++#endif
+     return status;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++}
++#endif
+ 
+ int
+ Cocoa_GL_GetSwapInterval(_THIS)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     NSOpenGLContext *nscontext;
+     GLint value;
+     int status = 0;
+@@ -380,27 +453,54 @@
+         status = (int)value;
+     }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    [pool release];
++#endif
+     return status;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++}
++#endif
+ 
+ void
+ Cocoa_GL_SwapWindow(_THIS, SDL_Window * window)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     SDLOpenGLContext* nscontext = (SDLOpenGLContext*)SDL_GL_GetCurrentContext();
+     [nscontext flushBuffer];
+     [nscontext updateIfNeeded];
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
+ 
+ void
+ Cocoa_GL_DeleteContext(_THIS, SDL_GLContext context)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     SDLOpenGLContext *nscontext = (SDLOpenGLContext *)context;
+ 
+     [nscontext setWindow:NULL];
+     [nscontext release];
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
+ 
+ #endif /* SDL_VIDEO_OPENGL_CGL */
+ 
+diff -ru SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoashape.m SDL2-2.0.5/src/video/cocoa/SDL_cocoashape.m
+--- SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoashape.m	2016-10-20 05:56:26.000000000 +0200
++++ SDL2-2.0.5/src/video/cocoa/SDL_cocoashape.m	2018-05-23 14:54:15.000000000 +0200
+@@ -73,8 +73,13 @@
+ 
+ int
+ Cocoa_SetWindowShape(SDL_WindowShaper *shaper, SDL_Surface *shape, SDL_WindowShapeMode *shape_mode)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     SDL_ShapeData* data = (SDL_ShapeData*)shaper->driverdata;
+     SDL_WindowData* windata = (SDL_WindowData*)shaper->window->driverdata;
+     SDL_CocoaClosure closure;
+@@ -97,8 +102,15 @@
+     SDL_TraverseShapeTree(data->shape,&ConvertRects,&closure);
+     [closure.path addClip];
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    [pool release];
++#endif
+     return 0;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++}
++#endif
+ 
+ int
+ Cocoa_ResizeWindowShape(SDL_Window *window)
+diff -ru SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoavideo.m SDL2-2.0.5/src/video/cocoa/SDL_cocoavideo.m
+--- SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoavideo.m	2016-10-20 05:56:26.000000000 +0200
++++ SDL2-2.0.5/src/video/cocoa/SDL_cocoavideo.m	2018-05-23 16:33:03.000000000 +0200
+@@ -22,6 +22,13 @@
+ 
+ #if SDL_VIDEO_DRIVER_COCOA
+ 
++#if defined(__APPLE__) && defined(__POWERPC__) && !defined(__APPLE_ALTIVEC__)
++#include <altivec.h>
++#undef bool
++#undef vector
++#undef pixel
++#endif
++
+ #include "SDL.h"
+ #include "SDL_endian.h"
+ #include "SDL_cocoavideo.h"
+@@ -150,10 +157,15 @@
+     Cocoa_InitKeyboard(_this);
+     Cocoa_InitMouse(_this);
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+     data->allow_spaces = ((floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6) && SDL_GetHintBoolean(SDL_HINT_VIDEO_MAC_FULLSCREEN_SPACES, SDL_TRUE));
+ 
+     /* The IOPM assertion API can disable the screensaver as of 10.7. */
+     data->screensaver_use_iopm = floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6;
++#else
++    data->allow_spaces = 0;
++    data->screensaver_use_iopm = 0;
++#endif
+ 
+     return 0;
+ }
+diff -ru SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoawindow.h SDL2-2.0.5/src/video/cocoa/SDL_cocoawindow.h
+--- SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoawindow.h	2016-10-20 05:56:26.000000000 +0200
++++ SDL2-2.0.5/src/video/cocoa/SDL_cocoawindow.h	2018-05-23 14:54:15.000000000 +0200
+@@ -35,7 +35,11 @@
+     PENDING_OPERATION_MINIMIZE
+ } PendingWindowOperation;
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+ @interface Cocoa_WindowListener : NSResponder <NSWindowDelegate> {
++#else
++@interface Cocoa_WindowListener : NSResponder {
++#endif
+     SDL_WindowData *_data;
+     BOOL observingVisible;
+     BOOL wasCtrlLeft;
+@@ -75,7 +79,9 @@
+ -(void) windowDidEnterFullScreen:(NSNotification *) aNotification;
+ -(void) windowWillExitFullScreen:(NSNotification *) aNotification;
+ -(void) windowDidExitFullScreen:(NSNotification *) aNotification;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ -(NSApplicationPresentationOptions)window:(NSWindow *)window willUseFullScreenPresentationOptions:(NSApplicationPresentationOptions)proposedOptions;
++#endif
+ 
+ /* See if event is in a drag area, toggle on window dragging. */
+ -(BOOL) processHitTest:(NSEvent *)theEvent;
+@@ -98,7 +104,17 @@
+ -(void) touchesCancelledWithEvent:(NSEvent *) theEvent;
+ 
+ /* Touch event handling */
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ -(void) handleTouches:(NSTouchPhase) phase withEvent:(NSEvent*) theEvent;
++#else
++typedef enum {
++    COCOA_TOUCH_DOWN,
++    COCOA_TOUCH_UP,
++    COCOA_TOUCH_MOVE,
++    COCOA_TOUCH_CANCELLED
++} cocoaTouchType;
++-(void) handleTouches:(cocoaTouchType)type withEvent:(NSEvent*) event;
++#endif
+ 
+ @end
+ /* *INDENT-ON* */
+diff -ru SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoawindow.m SDL2-2.0.5/src/video/cocoa/SDL_cocoawindow.m
+--- SDL2-2.0.5-orig/src/video/cocoa/SDL_cocoawindow.m	2016-10-20 05:56:26.000000000 +0200
++++ SDL2-2.0.5/src/video/cocoa/SDL_cocoawindow.m	2018-05-23 16:44:16.000000000 +0200
+@@ -23,7 +23,9 @@
+ #if SDL_VIDEO_DRIVER_COCOA
+ 
+ #if MAC_OS_X_VERSION_MAX_ALLOWED < 1070
++#if 0
+ # error SDL for Mac OS X must be built with a 10.7 SDK or above.
++#endif
+ #endif /* MAC_OS_X_VERSION_MAX_ALLOWED < 1070 */
+ 
+ #include "SDL_syswm.h"
+@@ -53,7 +55,11 @@
+ #define FULLSCREEN_MASK (SDL_WINDOW_FULLSCREEN_DESKTOP | SDL_WINDOW_FULLSCREEN)
+ 
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++@interface SDLWindow : NSWindow
++#else
+ @interface SDLWindow : NSWindow <NSDraggingDestination>
++#endif
+ /* These are needed for borderless/fullscreen windows */
+ - (BOOL)canBecomeKeyWindow;
+ - (BOOL)canBecomeMainWindow;
+@@ -114,8 +120,13 @@
+ }
+ 
+ - (BOOL)performDragOperation:(id <NSDraggingInfo>)sender
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool;
++#endif
+     SDL_VideoDevice *_this = SDL_GetVideoDevice();
+     NSPasteboard *pasteboard = [sender draggingPasteboard];
+     NSArray *types = [NSArray arrayWithObject:NSFilenamesPboardType];
+@@ -131,11 +142,16 @@
+         return NO;
+     }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    pool = [[NSAutoreleasePool alloc] init];
++#endif
++
+     SDL_assert([desiredType isEqualToString:NSFilenamesPboardType]);
+     NSArray *array = [pasteboard propertyListForType:@"NSFilenamesPboardType"];
+ 
+     for (NSString *path in array) {
+         NSURL *fileURL = [NSURL fileURLWithPath:path];
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+         NSNumber *isAlias = nil;
+ 
+         [fileURL getResourceValue:&isAlias forKey:NSURLIsAliasFileKey error:nil];
+@@ -156,6 +172,7 @@
+                 }
+             }
+         }
++#endif
+ 
+         /* !!! FIXME: is there a better way to do this? */
+         if (_this) {
+@@ -168,13 +185,23 @@
+         }
+ 
+         if (!SDL_SendDropFile(sdlwindow, [[fileURL path] UTF8String])) {
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++            [pool release];
++#endif
+             return NO;
+         }
+     }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    [pool release];
++#endif
+     SDL_SendDropComplete(sdlwindow);
+     return YES;
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++}
++#else
+ }}
++#endif
+ 
+ - (BOOL)wantsPeriodicDraggingUpdates
+ {
+@@ -284,11 +311,13 @@
+         [center addObserver:self selector:@selector(windowDidDeminiaturize:) name:NSWindowDidDeminiaturizeNotification object:window];
+         [center addObserver:self selector:@selector(windowDidBecomeKey:) name:NSWindowDidBecomeKeyNotification object:window];
+         [center addObserver:self selector:@selector(windowDidResignKey:) name:NSWindowDidResignKeyNotification object:window];
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+         [center addObserver:self selector:@selector(windowDidChangeBackingProperties:) name:NSWindowDidChangeBackingPropertiesNotification object:window];
+         [center addObserver:self selector:@selector(windowWillEnterFullScreen:) name:NSWindowWillEnterFullScreenNotification object:window];
+         [center addObserver:self selector:@selector(windowDidEnterFullScreen:) name:NSWindowDidEnterFullScreenNotification object:window];
+         [center addObserver:self selector:@selector(windowWillExitFullScreen:) name:NSWindowWillExitFullScreenNotification object:window];
+         [center addObserver:self selector:@selector(windowDidExitFullScreen:) name:NSWindowDidExitFullScreenNotification object:window];
++#endif
+         [center addObserver:self selector:@selector(windowDidFailToEnterFullScreen:) name:@"NSWindowDidFailToEnterFullScreenNotification" object:window];
+         [center addObserver:self selector:@selector(windowDidFailToExitFullScreen:) name:@"NSWindowDidFailToExitFullScreenNotification" object:window];
+     } else {
+@@ -379,7 +408,9 @@
+     inFullscreenTransition = YES;
+ 
+     /* you need to be FullScreenPrimary, or toggleFullScreen doesn't work. Unset it again in windowDidExitFullScreen. */
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+     [nswindow setCollectionBehavior:NSWindowCollectionBehaviorFullScreenPrimary];
++#endif
+     [nswindow performSelectorOnMainThread: @selector(toggleFullScreen:) withObject:nswindow waitUntilDone:NO];
+     return YES;
+ }
+@@ -415,11 +446,13 @@
+         [center removeObserver:self name:NSWindowDidDeminiaturizeNotification object:window];
+         [center removeObserver:self name:NSWindowDidBecomeKeyNotification object:window];
+         [center removeObserver:self name:NSWindowDidResignKeyNotification object:window];
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+         [center removeObserver:self name:NSWindowDidChangeBackingPropertiesNotification object:window];
+         [center removeObserver:self name:NSWindowWillEnterFullScreenNotification object:window];
+         [center removeObserver:self name:NSWindowDidEnterFullScreenNotification object:window];
+         [center removeObserver:self name:NSWindowWillExitFullScreenNotification object:window];
+         [center removeObserver:self name:NSWindowDidExitFullScreenNotification object:window];
++#endif
+         [center removeObserver:self name:@"NSWindowDidFailToEnterFullScreenNotification" object:window];
+         [center removeObserver:self name:@"NSWindowDidFailToExitFullScreenNotification" object:window];
+     } else {
+@@ -594,9 +627,11 @@
+         [NSMenu setMenuBarVisible:NO];
+     }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+     const unsigned int newflags = [NSEvent modifierFlags] & NSAlphaShiftKeyMask;
+     _data->videodata->modifierFlags = (_data->videodata->modifierFlags & ~NSAlphaShiftKeyMask) | newflags;
+     SDL_ToggleModState(KMOD_CAPS, newflags != 0);
++#endif
+ }
+ 
+ - (void)windowDidResignKey:(NSNotification *)aNotification
+@@ -623,6 +658,7 @@
+ 
+ - (void)windowDidChangeBackingProperties:(NSNotification *)aNotification
+ {
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+     NSNumber *oldscale = [[aNotification userInfo] objectForKey:NSBackingPropertyOldScaleFactorKey];
+ 
+     if (inFullscreenTransition) {
+@@ -635,6 +671,7 @@
+         _data->window->h = 0;
+         [self windowDidResize:aNotification];
+     }
++#endif
+ }
+ 
+ - (void)windowWillEnterFullScreen:(NSNotification *)aNotification
+@@ -735,12 +772,14 @@
+         [nswindow miniaturize:nil];
+     } else {
+         /* Adjust the fullscreen toggle button and readd menu now that we're here. */
++#if MAC_OS_X_VERSION_MIN_REQUIRED > 1070
+         if (window->flags & SDL_WINDOW_RESIZABLE) {
+             /* resizable windows are Spaces-friendly: they get the "go fullscreen" toggle button on their titlebar. */
+             [nswindow setCollectionBehavior:NSWindowCollectionBehaviorFullScreenPrimary];
+         } else {
+             [nswindow setCollectionBehavior:NSWindowCollectionBehaviorManaged];
+         }
++#endif
+         [NSMenu setMenuBarVisible:YES];
+ 
+         pendingWindowOperation = PENDING_OPERATION_NONE;
+@@ -758,6 +797,7 @@
+     }
+ }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ -(NSApplicationPresentationOptions)window:(NSWindow *)window willUseFullScreenPresentationOptions:(NSApplicationPresentationOptions)proposedOptions
+ {
+     if ((_data->window->flags & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN_DESKTOP) {
+@@ -766,6 +806,7 @@
+         return proposedOptions;
+     }
+ }
++#endif
+ 
+ 
+ /* We'll respond to key events by doing nothing so we don't beep.
+@@ -992,6 +1033,7 @@
+ 
+ - (void)touchesBeganWithEvent:(NSEvent *) theEvent
+ {
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+     NSSet *touches = [theEvent touchesMatchingPhase:NSTouchPhaseAny inView:nil];
+     int existingTouchCount = 0;
+ 
+@@ -1012,25 +1054,89 @@
+ 
+     DLog("Began Fingers: %lu .. existing: %d", (unsigned long)[touches count], existingTouchCount);
+     [self handleTouches:NSTouchPhaseBegan withEvent:theEvent];
++#endif
+ }
+ 
+ - (void)touchesMovedWithEvent:(NSEvent *) theEvent
+ {
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+     [self handleTouches:NSTouchPhaseMoved withEvent:theEvent];
++#endif
+ }
+ 
+ - (void)touchesEndedWithEvent:(NSEvent *) theEvent
+ {
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+     [self handleTouches:NSTouchPhaseEnded withEvent:theEvent];
++#endif
+ }
+ 
+ - (void)touchesCancelledWithEvent:(NSEvent *) theEvent
+ {
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+     [self handleTouches:NSTouchPhaseCancelled withEvent:theEvent];
++#endif
+ }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
+ - (void)handleTouches:(NSTouchPhase) phase withEvent:(NSEvent *) theEvent
++#else
++- (void)handleTouches:(cocoaTouchType)type withEvent:(NSEvent *)event
++#endif
+ {
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    NSSet *touches = 0;
++    NSEnumerator *enumerator;
++    NSTouch *touch;
++
++    switch (type) {
++        case COCOA_TOUCH_DOWN:
++            touches = [event touchesMatchingPhase:NSTouchPhaseBegan inView:nil];
++            break;
++        case COCOA_TOUCH_UP:
++            touches = [event touchesMatchingPhase:NSTouchPhaseEnded inView:nil];
++            break;
++        case COCOA_TOUCH_CANCELLED:
++            touches = [event touchesMatchingPhase:NSTouchPhaseCancelled inView:nil];
++            break;
++        case COCOA_TOUCH_MOVE:
++            touches = [event touchesMatchingPhase:NSTouchPhaseMoved inView:nil];
++            break;
++    }
++
++    enumerator = [touches objectEnumerator];
++    touch = (NSTouch*)[enumerator nextObject];
++    while (touch) {
++        const SDL_TouchID touchId = (SDL_TouchID)(intptr_t)[touch device];
++        if (!SDL_GetTouch(touchId)) {
++            if (SDL_AddTouch(touchId, "") < 0) {
++                return;
++            }
++        }
++
++        const SDL_FingerID fingerId = (SDL_FingerID)(intptr_t)[touch identity];
++        float x = [touch normalizedPosition].x;
++        float y = [touch normalizedPosition].y;
++        /* Make the origin the upper left instead of the lower left */
++        y = 1.0f - y;
++
++        switch (type) {
++        case COCOA_TOUCH_DOWN:
++            SDL_SendTouch(touchId, fingerId, SDL_TRUE, x, y, 1.0f);
++            break;
++        case COCOA_TOUCH_UP:
++        case COCOA_TOUCH_CANCELLED:
++            SDL_SendTouch(touchId, fingerId, SDL_FALSE, x, y, 1.0f);
++            break;
++        case COCOA_TOUCH_MOVE:
++            SDL_SendTouchMotion(touchId, fingerId, x, y, 1.0f);
++            break;
++        }
++
++        touch = (NSTouch*)[enumerator nextObject];
++     }
++#else
+     NSSet *touches = [theEvent touchesMatchingPhase:phase inView:nil];
+ 
+     for (NSTouch *touch in touches) {
+@@ -1060,7 +1166,9 @@
+             break;
+         }
+     }
++#endif
+ }
++#endif
+ 
+ @end
+ 
+@@ -1127,8 +1235,13 @@
+ 
+ static int
+ SetupWindowData(_THIS, SDL_Window * window, NSWindow *nswindow, SDL_bool created)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool;
++#endif
+     SDL_VideoData *videodata = (SDL_VideoData *) _this->driverdata;
+     SDL_WindowData *data;
+ 
+@@ -1143,6 +1256,9 @@
+     data->videodata = videodata;
+     data->nscontexts = [[NSMutableArray alloc] init];
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    pool = [[NSAutoreleasePool alloc] init];
++#endif
+     /* Create an event listener for the window */
+     data->listener = [[Cocoa_WindowListener alloc] init];
+ 
+@@ -1203,15 +1319,27 @@
+      */
+     [nswindow setOneShot:NO];
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    [pool release];
++#endif
+     /* All done! */
+     window->driverdata = data;
+     return 0;
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++}
++#else
+ }}
++#endif
+ 
+ int
+ Cocoa_CreateWindow(_THIS, SDL_Window * window)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     SDL_VideoData *videodata = (SDL_VideoData *) _this->driverdata;
+     NSWindow *nswindow;
+     SDL_VideoDisplay *display = SDL_GetDisplayForWindow(window);
+@@ -1252,6 +1380,7 @@
+     [nswindow setBackgroundColor:[NSColor blackColor]];
+ 
+     if (videodata->allow_spaces) {
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+         SDL_assert(floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6);
+         SDL_assert([nswindow respondsToSelector:@selector(toggleFullScreen:)]);
+         /* we put FULLSCREEN_DESKTOP windows in their own Space, without a toggle button or menubar, later */
+@@ -1259,6 +1388,7 @@
+             /* resizable windows are Spaces-friendly: they get the "go fullscreen" toggle button on their titlebar. */
+             [nswindow setCollectionBehavior:NSWindowCollectionBehaviorFullScreenPrimary];
+         }
++#endif
+     }
+ 
+     /* Create a default view for this window */
+@@ -1277,18 +1407,30 @@
+ 
+     /* Allow files and folders to be dragged onto the window by users */
+     [nswindow registerForDraggedTypes:[NSArray arrayWithObject:(NSString *)kUTTypeFileURL]];
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    [pool release];
++#endif
+ 
+     if (SetupWindowData(_this, window, nswindow, SDL_TRUE) < 0) {
+         [nswindow release];
+         return -1;
+     }
+     return 0;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++}
++#endif
+ 
+ int
+ Cocoa_CreateWindowFrom(_THIS, SDL_Window * window, const void *data)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     NSWindow *nswindow = (NSWindow *) data;
+     NSString *title;
+ 
+@@ -1299,34 +1441,64 @@
+     }
+ 
+     return SetupWindowData(_this, window, nswindow, SDL_FALSE);
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
+ 
+ void
+ Cocoa_SetWindowTitle(_THIS, SDL_Window * window)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     const char *title = window->title ? window->title : "";
+     NSWindow *nswindow = ((SDL_WindowData *) window->driverdata)->nswindow;
+     NSString *string = [[NSString alloc] initWithUTF8String:title];
+     [nswindow setTitle:string];
+     [string release];
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
+ 
+ void
+ Cocoa_SetWindowIcon(_THIS, SDL_Window * window, SDL_Surface * icon)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     NSImage *nsimage = Cocoa_CreateImage(icon);
+ 
+     if (nsimage) {
+         [NSApp setApplicationIconImage:nsimage];
+     }
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
+ 
+ void
+ Cocoa_SetWindowPosition(_THIS, SDL_Window * window)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     SDL_WindowData *windata = (SDL_WindowData *) window->driverdata;
+     NSWindow *nswindow = windata->nswindow;
+     NSRect rect;
+@@ -1344,12 +1516,22 @@
+     s_moveHack = moveHack;
+ 
+     ScheduleContextUpdates(windata);
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
+ 
+ void
+ Cocoa_SetWindowSize(_THIS, SDL_Window * window)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     SDL_WindowData *windata = (SDL_WindowData *) window->driverdata;
+     NSWindow *nswindow = windata->nswindow;
+     NSRect rect;
+@@ -1371,12 +1553,22 @@
+     s_moveHack = moveHack;
+ 
+     ScheduleContextUpdates(windata);
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
+ 
+ void
+ Cocoa_SetWindowMinimumSize(_THIS, SDL_Window * window)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     SDL_WindowData *windata = (SDL_WindowData *) window->driverdata;
+ 
+     NSSize minSize;
+@@ -1384,12 +1576,22 @@
+     minSize.height = window->min_h;
+ 
+     [windata->nswindow setContentMinSize:minSize];
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
+ 
+ void
+ Cocoa_SetWindowMaximumSize(_THIS, SDL_Window * window)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     SDL_WindowData *windata = (SDL_WindowData *) window->driverdata;
+ 
+     NSSize maxSize;
+@@ -1397,12 +1599,22 @@
+     maxSize.height = window->max_h;
+ 
+     [windata->nswindow setContentMaxSize:maxSize];
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
+ 
+ void
+ Cocoa_ShowWindow(_THIS, SDL_Window * window)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     SDL_WindowData *windowData = ((SDL_WindowData *) window->driverdata);
+     NSWindow *nswindow = windowData->nswindow;
+ 
+@@ -1411,21 +1623,41 @@
+         [nswindow makeKeyAndOrderFront:nil];
+         [windowData->listener resumeVisibleObservation];
+     }
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
+ 
+ void
+ Cocoa_HideWindow(_THIS, SDL_Window * window)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     NSWindow *nswindow = ((SDL_WindowData *) window->driverdata)->nswindow;
+ 
+     [nswindow orderOut:nil];
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
+ 
+ void
+ Cocoa_RaiseWindow(_THIS, SDL_Window * window)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     SDL_WindowData *windowData = ((SDL_WindowData *) window->driverdata);
+     NSWindow *nswindow = windowData->nswindow;
+ 
+@@ -1438,24 +1670,44 @@
+         [nswindow makeKeyAndOrderFront:nil];
+     }
+     [windowData->listener resumeVisibleObservation];
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
+ 
+ void
+ Cocoa_MaximizeWindow(_THIS, SDL_Window * window)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     SDL_WindowData *windata = (SDL_WindowData *) window->driverdata;
+     NSWindow *nswindow = windata->nswindow;
+ 
+     [nswindow zoom:nil];
+ 
+     ScheduleContextUpdates(windata);
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
+ 
+ void
+ Cocoa_MinimizeWindow(_THIS, SDL_Window * window)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     SDL_WindowData *data = (SDL_WindowData *) window->driverdata;
+     NSWindow *nswindow = data->nswindow;
+ 
+@@ -1464,12 +1716,22 @@
+     } else {
+         [nswindow miniaturize:nil];
+     }
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
+ 
+ void
+ Cocoa_RestoreWindow(_THIS, SDL_Window * window)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     NSWindow *nswindow = ((SDL_WindowData *) window->driverdata)->nswindow;
+ 
+     if ([nswindow isMiniaturized]) {
+@@ -1477,23 +1739,44 @@
+     } else if ((window->flags & SDL_WINDOW_RESIZABLE) && [nswindow isZoomed]) {
+         [nswindow zoom:nil];
+     }
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
+ 
+ void
+ Cocoa_SetWindowBordered(_THIS, SDL_Window * window, SDL_bool bordered)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     if (SetWindowStyle(window, GetWindowStyle(window))) {
+         if (bordered) {
+             Cocoa_SetWindowTitle(_this, window);  /* this got blanked out. */
+         }
+     }
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
++
+ 
+ void
+ Cocoa_SetWindowResizable(_THIS, SDL_Window * window, SDL_bool resizable)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     /* Don't set this if we're in a space!
+      * The window will get permanently stuck if resizable is false.
+      * -flibit
+@@ -1503,12 +1786,23 @@
+     if (![listener isInFullscreenSpace]) {
+         SetWindowStyle(window, GetWindowStyle(window));
+     }
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
++
+ 
+ void
+ Cocoa_SetWindowFullscreen(_THIS, SDL_Window * window, SDL_VideoDisplay * display, SDL_bool fullscreen)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     SDL_WindowData *data = (SDL_WindowData *) window->driverdata;
+     NSWindow *nswindow = data->nswindow;
+     NSRect rect;
+@@ -1579,7 +1873,12 @@
+     }
+ 
+     ScheduleContextUpdates(data);
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
+ 
+ int
+ Cocoa_SetWindowGammaRamp(_THIS, SDL_Window * window, const Uint16 * ramp)
+@@ -1664,8 +1963,13 @@
+ 
+ void
+ Cocoa_DestroyWindow(_THIS, SDL_Window * window)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     SDL_WindowData *data = (SDL_WindowData *) window->driverdata;
+ 
+     if (data) {
+@@ -1688,7 +1992,12 @@
+         SDL_free(data);
+     }
+     window->driverdata = NULL;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++    [pool release];
++}
++#endif
+ 
+ SDL_bool
+ Cocoa_GetWindowWMInfo(_THIS, SDL_Window * window, SDL_SysWMinfo * info)
+@@ -1720,8 +2029,13 @@
+ 
+ SDL_bool
+ Cocoa_SetWindowFullscreenSpace(SDL_Window * window, SDL_bool state)
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ { @autoreleasepool
+ {
++#else
++{
++    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
++#endif
+     SDL_bool succeeded = SDL_FALSE;
+     SDL_WindowData *data = (SDL_WindowData *) window->driverdata;
+ 
+@@ -1752,8 +2066,15 @@
+         succeeded = SDL_TRUE;
+     }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
++    [pool release];
++#endif
+     return succeeded;
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ }}
++#else
++}
++#endif
+ 
+ int
+ Cocoa_SetWindowHitTest(SDL_Window * window, SDL_bool enabled)


### PR DESCRIPTION
Hello and thank you very much for allowed also the PowerMac users to benefit from SDL2 libraries! Thanks to your work we have enjoyed programs like SDLmame and FS-UAE well after their official dismission from PPC development! The 2.0.3 version worked like a charm on G4 and G5 machines but the 2.0.5 seems to be have some issues and apps that compiled well with 2.0.3 crashes when built against 2.0.5 it looks like something in the 2.0.5 library is not working as expected when built on PPC machines... could you kindly look at your port to see if there are some endianess issues? Many thank in advance!